### PR TITLE
Upgrade kotest from 4.6.1 to 4.6.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,8 +22,7 @@ version.detekt=1.18.0
 ## unused
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
-version.kotest=4.6.1
-## # available=4.6.2
+version.kotest=4.6.2
 
 version.kotlin=1.5.20
 ## # available=1.5.21


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.